### PR TITLE
Add clear and delete actions to Cacheman

### DIFF
--- a/lib/cacheman.ex
+++ b/lib/cacheman.ex
@@ -178,6 +178,18 @@ defmodule Cacheman do
     GenServer.call(full_process_name(name), {:exists?, key})
   end
 
+  def delete(name, key) when is_binary(key) do
+    GenServer.call(full_process_name(name), {:delete, [key]})
+  end
+
+  def delete(name, keys) when is_list(keys) do
+    GenServer.call(full_process_name(name), {:delete, keys}
+  end
+
+  def clear(name) do
+    GenServer.call(full_process_name(name), {:clear})
+  end
+
   #
   # GenServer impl
   #
@@ -231,6 +243,25 @@ defmodule Cacheman do
         fully_qualified_key_name(opts, key),
         value,
         put_opts
+      ])
+
+    {:reply, response, opts}
+  end
+
+  def handle_call({:delete, keys}, _from, opts) do
+    response =
+      apply(opts.backend_module, :delete, [
+        opts.backend_pid,
+        keys |> Enum.map(fn key -> fully_qualified_key_name(opts, key) end)
+      ])
+
+    {:reply, response, opts}
+  end
+
+  def handle_call({:clear}, _from, opts) do
+    response =
+      apply(opts.backend_module, :clear, [
+        opts.backend_pid
       ])
 
     {:reply, response, opts}

--- a/lib/cacheman.ex
+++ b/lib/cacheman.ex
@@ -183,7 +183,7 @@ defmodule Cacheman do
   end
 
   def delete(name, keys) when is_list(keys) do
-    GenServer.call(full_process_name(name), {:delete, keys}
+    GenServer.call(full_process_name(name), {:delete, keys})
   end
 
   def clear(name) do

--- a/lib/cacheman/backend/redis.ex
+++ b/lib/cacheman/backend/redis.ex
@@ -39,6 +39,18 @@ defmodule Cacheman.Backend.Redis do
     end)
   end
 
+  def delete(conn, keys) do
+    :poolboy.transaction(conn, fn c ->
+      Redix.command(c, ["DEL"] ++ keys)
+    end)
+  end
+
+  def clear(conn) do
+    :poolboy.transaction(conn, fn c ->
+      Redix.command(c, ["FLUSHALL"])
+    end)
+  end
+
   def ttl_command(ttl: :infinity), do: []
   def ttl_command(ttl: ttl), do: ["PX", "#{ttl}"]
 end

--- a/test/cacheman_test.exs
+++ b/test/cacheman_test.exs
@@ -79,6 +79,36 @@ defmodule CachemanTest do
       assert Cacheman.exists?(:good, "test1")
       refute Cacheman.exists?(:good, "test2")
     end
+
+    test "clear" do
+      Cacheman.put(:good, "random-key", "hey")
+      assert Cacheman.exists?(:good, "random-key")
+      Cacheman.clear(:good)
+      refute Cacheman.exists?(:good, "random-key")
+    end
+
+    test "delete key" do
+      Cacheman.put(:good, "key1", "hehe")
+      assert Cacheman.exists?(:good, "key1")
+      Cacheman.delete(:good, "key1")
+      refute Cacheman.exists?(:good, "key1")
+    end
+
+    test "delete [keys]" do
+      Cacheman.put(:good, "key1", "it doesn't matter")
+      Cacheman.put(:good, "key2", "it doesn't matter")
+      Cacheman.put(:good, "key3", "it doesn't matter")
+
+      assert Cacheman.exists?(:good, "key1")
+      assert Cacheman.exists?(:good, "key1")
+      assert Cacheman.exists?(:good, "key1")
+
+      Cacheman.delete(:good, ["key1", "key2"])
+
+      refute Cacheman.exists?(:good, "key1")
+      refute Cacheman.exists?(:good, "key2")
+      assert Cacheman.exists?(:good, "key3")
+    end
   end
 
   describe "redis - broken" do


### PR DESCRIPTION
The `clear` is primarily handy for testing purposes to ensure test is always run with an empty cache.